### PR TITLE
Feat/store and autocomplete data

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ end_of_line = lf
 
 [*.html]
 indent_style = space
-indent_size = 2
+indent_size = 4
 
 [*.{js,json,yml}]
 indent_style = space

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 
-# Created by https://www.toptal.com/developers/gitignore/api/node,code,linux,vim,windows,macos
-# Edit at https://www.toptal.com/developers/gitignore?templates=node,code,linux,vim,windows,macos
+# Created by https://www.toptal.com/developers/gitignore/api/vim,node,code,macos,linux,windows,jetbrains+all
+# Edit at https://www.toptal.com/developers/gitignore?templates=vim,node,code,macos,linux,windows,jetbrains+all
 
 ### Code ###
 .vscode/*
@@ -9,6 +9,95 @@
 !.vscode/launch.json
 !.vscode/extensions.json
 *.code-workspace
+
+### JetBrains+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### JetBrains+all Patch ###
+# Ignores the whole .idea folder and all .iml files
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+
+.idea/
+
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
+*.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
 
 ### Linux ###
 *~
@@ -210,4 +299,4 @@ $RECYCLE.BIN/
 # Windows shortcuts
 *.lnk
 
-# End of https://www.toptal.com/developers/gitignore/api/node,code,linux,vim,windows,macos
+# End of https://www.toptal.com/developers/gitignore/api/vim,node,code,macos,linux,windows,jetbrains+all

--- a/package-lock.json
+++ b/package-lock.json
@@ -3112,6 +3112,11 @@
         "randomfill": "^1.0.3"
       }
     },
+    "crypto-js": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
+      "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
+    },
     "css-blank-pseudo": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz",
@@ -6179,6 +6184,11 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
+    },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY="
     },
     "magic-string": {
       "version": "0.22.5",
@@ -9514,6 +9524,15 @@
       "dev": true,
       "requires": {
         "xmlchars": "^2.1.1"
+      }
+    },
+    "secure-ls": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/secure-ls/-/secure-ls-1.2.6.tgz",
+      "integrity": "sha512-g8vUSKl6elSfyAUHodybnNkuZW+mUYEOWj4SZIDg+xoQ1dq5ddktBoOFrtxQBUl88ZyAJOtGWQ1PRaOxkTAuZQ==",
+      "requires": {
+        "crypto-js": "^3.1.6",
+        "lz-string": "^1.4.4"
       }
     },
     "semver": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "@fortawesome/free-solid-svg-icons": "^5.15.1",
     "bootstrap": "^4.5.3",
     "pdf-lib": "^1.11.2",
-    "qrcode": "^1.4.4"
+    "qrcode": "^1.4.4",
+    "secure-ls": "^1.2.6"
   },
   "browserslist": [
     "last 5 versions"

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -567,7 +567,7 @@ input:valid+span:after {
   }
 }
 
-#snackbar {
+#snackbar, #snackbar-cleardata {
   min-width: 250px;
   color: #fff;
   text-align: center;
@@ -584,7 +584,7 @@ input:valid+span:after {
   transition: all 0.5s ease-in-out;
 }
 
-#snackbar.show {
+#snackbar.show, #snackbar-cleardata {
   opacity: 1;
 }
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -154,6 +154,10 @@ p {
   transform: translateY(-2px);
 }
 
+#form-profile #formgroup-storedata {
+  user-select: none;
+}
+
 @media (prefers-color-scheme: dark) {
   #form-profile .form-radio-label .form-check-label {
     color: #ddd;

--- a/src/index.html
+++ b/src/index.html
@@ -362,6 +362,9 @@
             <div class="bg-primary  d-none" id="snackbar">
               L'attestation est téléchargée sur votre appareil.
             </div>
+            <div class="bg-primary  d-none" id="snackbar-cleardata">
+                Les données du formulaire ont été effacées.
+            </div>
         </form>
     </div>
 

--- a/src/index.html
+++ b/src/index.html
@@ -65,6 +65,7 @@
 
             <div class="form-group">
                 <label for="field-firstname" id="field-firstname-label">Prénom</label>
+                <a id="cleardata" class="float-right" href="javascript:void(0)">Effacer les données du formulaire ?</a>
                 <div class="input-group  align-items-center">
                     <input
                         type="text"
@@ -343,6 +344,19 @@
 
             <p class="text-center mt-5">
                 <button type="button" id="generate-btn" class="btn btn-primary btn-attestation"><span ><i class="fa fa-file-pdf inline-block mr-1"></i>  Générer mon attestation</span></button>
+            </p>
+
+            <p id="formgroup-storedata" class="form-check text-center">
+                <input
+                    class="form-check-input"
+                    type="checkbox"
+                    name="storedata"
+                    id="field-storedata"
+                    value="storedata"
+                >
+                <label class="form-check-label" for="checkbox-storedata">
+                    Stocker mes données sur l'appareil afin de remplir automatiquement mes futures attestations
+                </label>
             </p>
 
             <div class="bg-primary  d-none" id="snackbar">

--- a/src/js/form-util.js
+++ b/src/js/form-util.js
@@ -5,12 +5,15 @@ import { generatePdf } from './pdf-util'
 import SecureLS from 'secure-ls'
 
 const secureLS = new SecureLS({ encodingType: 'aes' })
+const formProfile = $('#form-profile')
 const formInputs = $$('#form-profile input')
 const snackbar = $('#snackbar')
 const reasonInputs = [...$$('input[name="field-reason"]')]
 const reasonFieldset = $('#reason-fieldset')
 const reasonAlert = reasonFieldset.querySelector('.msg-alert')
 const releaseDateInput = $('#field-datesortie')
+const releaseTimeInput = $('#field-heuresortie')
+const storeDataInput = $('#field-storedata')
 
 const conditions = {
   '#field-firstname': {
@@ -63,8 +66,27 @@ function validateAriaFields () {
 }
 
 function updateSecureLS () {
-  secureLS.set('profile', getProfile())
-  secureLS.set('reason', getReason())
+  if (wantDataToBeStored() === true) {
+    secureLS.set('profile', getProfile())
+    secureLS.set('reason', getReason())
+  } else {
+    clearSecureLS()
+  }
+}
+
+function clearSecureLS () {
+  secureLS.clear()
+}
+
+function clearForm () {
+  formProfile.reset()
+}
+
+function setCurrentDate () {
+  const currentDate = new Date()
+
+  releaseDateInput.value = getFormattedDate(currentDate)
+  releaseTimeInput.value = currentDate.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })
 }
 
 export function setReleaseDateTime () {
@@ -89,8 +111,11 @@ export function getProfile () {
 
 export function getReason () {
   const checkedReasonInput = reasonInputs.find(input => input.checked)
-  const val = checkedReasonInput?.value
-  return val
+  return checkedReasonInput?.value
+}
+
+export function wantDataToBeStored () {
+  return storeDataInput.checked
 }
 
 export function prepareInputs () {
@@ -110,6 +135,9 @@ export function prepareInputs () {
         break
       case 'field-reason' :
         if (lsReason && input.value === lsReason) input.checked = true
+        break
+      case 'storedata' :
+        if (lsReason || lsProfile) input.checked = true
         break
       default :
         if (lsProfile) input.value = lsProfile[input.name]
@@ -143,6 +171,16 @@ export function prepareInputs () {
       reasonFieldset.classList.toggle('fieldset-error', isInError)
       reasonAlert.classList.toggle('hidden', !isInError)
     })
+  })
+
+  $('#formgroup-storedata').addEventListener('click', (event) => {
+    (storeDataInput.checked) ? storeDataInput.checked = false : storeDataInput.checked = true
+  })
+
+  $('#cleardata').addEventListener('click', (event) => {
+    clearSecureLS()
+    clearForm()
+    setCurrentDate()
   })
 
   $('#generate-btn').addEventListener('click', async (event) => {

--- a/src/js/form-util.js
+++ b/src/js/form-util.js
@@ -8,6 +8,7 @@ const secureLS = new SecureLS({ encodingType: 'aes' })
 const formProfile = $('#form-profile')
 const formInputs = $$('#form-profile input')
 const snackbar = $('#snackbar')
+const clearDataSnackbar = $('#snackbar-cleardata')
 const reasonInputs = [...$$('input[name="field-reason"]')]
 const reasonFieldset = $('#reason-fieldset')
 const reasonAlert = reasonFieldset.querySelector('.msg-alert')
@@ -87,6 +88,16 @@ function setCurrentDate () {
 
   releaseDateInput.value = getFormattedDate(currentDate)
   releaseTimeInput.value = currentDate.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })
+}
+
+function showSnackbar (snackbarToShow, showDuration = 6000) {
+  snackbarToShow.classList.remove('d-none')
+  setTimeout(() => snackbarToShow.classList.add('show'), 100)
+
+  setTimeout(function () {
+    snackbarToShow.classList.remove('show')
+    setTimeout(() => snackbarToShow.classList.add('d-none'), 500)
+  }, showDuration)
 }
 
 export function setReleaseDateTime () {
@@ -181,6 +192,7 @@ export function prepareInputs () {
     clearSecureLS()
     clearForm()
     setCurrentDate()
+    showSnackbar(clearDataSnackbar, 1200)
   })
 
   $('#generate-btn').addEventListener('click', async (event) => {
@@ -211,12 +223,6 @@ export function prepareInputs () {
 
     downloadBlob(pdfBlob, `attestation-${creationDate}_${creationHour}.pdf`)
 
-    snackbar.classList.remove('d-none')
-    setTimeout(() => snackbar.classList.add('show'), 100)
-
-    setTimeout(function () {
-      snackbar.classList.remove('show')
-      setTimeout(() => snackbar.classList.add('d-none'), 500)
-    }, 6000)
+    showSnackbar(snackbar)
   })
 }

--- a/src/js/form-util.js
+++ b/src/js/form-util.js
@@ -109,10 +109,10 @@ export function prepareInputs () {
         input.value = formattedTime
         break
       case 'field-reason' :
-        if (input.value === lsReason) input.checked = true
+        if (lsReason && input.value === lsReason) input.checked = true
         break
       default :
-        input.value = lsProfile[input.name]
+        if (lsProfile) input.value = lsProfile[input.name]
     }
     const exempleElt = input.parentNode.parentNode.querySelector('.exemple')
     const validitySpan = input.parentNode.parentNode.querySelector('.validity')


### PR DESCRIPTION
Ajout d'une système permettant d'enregistrer et restaurer automatiquement les données du formulaire

But :
Gain de temps, surtout quand la raison est la même tous les soirs (exemple : sortir un animal de compagnie).
Après avoir utilisé le formulaire une première fois, il n'y a plus qu'à appuyer sur "Générer l'attestation" pour les suivantes.

Demo : https://autocovid19.oa.r.appspot.com/

Fonctionnalités introduites par cette PR :
- enregistrement chiffré des données du formulaire dans le localStorage à la génération du pdf (utilisation de la lib [secure-ls](https://github.com/softvar/secure-ls) pour le stockage des données chiffrées)
- récupération des données chiffrées à l'ouverture du formulaire avec autocompletion des champs (profile et choix raison)
- autocompletion de la date de sortie (avec date et heure actuelle)
- ajout d'une checkbox pour choisir ou non d'enregister les données et d'un lien pour effacer les données enregistrées :
  - si la checkbox est décochée, les données sont effacées du localStorage mais pas du formulaire
  - si le lien pour effacer les données est cliqué,  les données sont effacées du localStorage et du formulaire

Divers/Dev :
- Ajout des IDE Jetbrains au .gitignore
- Modification du fichier .editorconfig afin de correspondre au format du fichier index.html (4 espaces pour l'indentation sur index.html alors que l'editorconfig en indiquait 2)


Bien sûr, selon vos besoins je peux adapter cette PR (par exemple en n'enregistrant pas certains champs comme la raison, ou retirer l'autocompletion avec l'heure actuelle pour ne garder que la date, ou encore retirer les changements de l'.editorconfig). Mais personnellement, pour des raisons pratiques (j'ai un chien à sortir tous les soirs, donc toujours la même raison à chaque fois), je préfère utiliser ma propre version et compte la proposer à mon entourage dès qu'elle sera publiée.


Idées d'évolution dans un second temps avec maj UI/UX :
  - si données trouvées en localStorage, alors au lieu d'afficher le formulaire, on affiche un résumé rapide et on a un bouton génération / modification à portée de main (pour éviter de scroll le formulaire à chaque fois) : le wording est à définir, mais ça pourrait être quelque chose du style "Souhaitez-vous générer une attestation pour [prenom + nom], pour une sortie le [date + heure] ayant pour motif [motif] ?".
    - "Oui, générer mon attestation" => génération directe comme actuellement
    - "Non, changer le motif de sortie" => affichage des radios de choix du motif uniquement + bouton génération
    - "Non, changer la date/heure de sortie" => affichage de date+heure sortie uniquement + bouton génération
    - "Non, faire une attestation pour une autre personne" => effacement du localstorage puis ouverture du formulaire vide
    - "Non, effacer mes données stockées" => effacement du localstorage et du formulaire + texte confirmation