### PR TITLE
Align Covid subtitle vertically

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -279,7 +279,7 @@ input:valid+span:after {
 }
 
 .covid-subtitle {
-  display: inline-block;
+  display: flex;
   align-items: center;
   font-size: 0.40em;
   padding: 0.3em;


### PR DESCRIPTION
Hey 👋 

it's really frustrating to see this title not aligned at the top of the page so I thought it would be nice to fix this (especially as it only requires a micro update).

So it update the title layout from...

![image](https://user-images.githubusercontent.com/31794680/97117147-28fd6280-1702-11eb-9282-9d90993d2ba2.png)

...to

![image](https://user-images.githubusercontent.com/31794680/97117163-3a466f00-1702-11eb-9295-89c4238b5b84.png)
