### PR TITLE
Preserve logo image legibility on small screens

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -254,6 +254,7 @@ input:valid+span:after {
 
 .logo {
   width: 50%;
+  min-width: 240px;
 }
 
 .covid-title {


### PR DESCRIPTION
Over small screen devices (≲ 375 wide) the logo gets really small and the _'Liberté, égalité, fraternité'_ motto is hardly readable.
By setting a minimum width, the SVG image reads and looks much better.
![attestation-logo](https://user-images.githubusercontent.com/703744/97624698-c076f400-1a27-11eb-9c94-0ab7ef3f90d7.png)
